### PR TITLE
Adapting to our iotbase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ idf_component_register(
     INCLUDE_DIRS
         .
     REQUIRES
-        arduino-esp32
+        arduino
         esp_rom
         driver
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ idf_component_register(
         driver
 
     REQUIRED_IDF_TARGETS        
-        espe32
+        esp32
 )
 
 target_compile_options(${COMPONENT_TARGET}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ idf_component_register(
         arduino
         esp_rom
         driver
+
+    REQUIRED_IDF_TARGETS        
+        espe32
 )
 
 target_compile_options(${COMPONENT_TARGET}

--- a/FastLED.cpp
+++ b/FastLED.cpp
@@ -1,6 +1,5 @@
 #define FASTLED_INTERNAL
 #include "FastLED.h"
-#include "esp32-hal-misc.h"
 
 #if defined(__SAM3X8E__)
 volatile uint32_t fuckit;


### PR DESCRIPTION
Hi!

I've made a fork from your 'fixes' branch to play with an m5station board in an ESP-IDF based project.
I am using the 5.1.1 espressif toolchain, and followed these (official) instructions to integrate Arduino in ESP-IDF-based project.

https://docs.espressif.com/projects/arduino-esp32/en/latest/esp-idf_component.html

As you can see the official documentation tells us to put the arduino-esp32 into a component named 'arduino'.  This is the reason why I had to change the "requires" entry in the CMakeLists.txt.

The other change was done to be able to compile the project without errors.  I assume it is because I am using a quite new version of ESP-IDF (5.1.1).

I have thought that maybe you want to incorporate these changes.  Maybe the second one breaks compatibility with 4.x, I don't know, so maybe you would prefer cherry-picking just the first.

Regards.  Thank you for sharing.

Tx

